### PR TITLE
Add Debug flag in Panel Options

### DIFF
--- a/src/BasePanel.tsx
+++ b/src/BasePanel.tsx
@@ -165,7 +165,7 @@ const _BasePanel: React.FC<Props> = (props: Props) => {
 
   const [isDatasourceConfigured, changeIsDatasourceConfigured] = useState(false);
   const { data: value, width, fieldConfig, height, options, openGenericDialog } = props;
-  const { panelType, overrideBISettings, backgroundImageURL } = options;
+  const { panelType, isDebugMode, overrideBISettings, backgroundImageURL } = options;
   const [dataSource, setDataSource] = useState<any>({});
   const [isRunning, setIsRunning] = useState(false);
   const [currentPanelType, updatePanelType] = useState<string>(panelType);
@@ -345,11 +345,13 @@ const _BasePanel: React.FC<Props> = (props: Props) => {
 
   return (
     <div className={computedWrapperClassname}>
-      <div style={{ float: 'right', transform: 'translate(-12px, -32px)' }}>
-        <HorizontalGroup>
-          <IconButton name="cloud-upload" size="lg" key="cloud-upload" onClick={openPriorityWriter} />
-        </HorizontalGroup>
-      </div>
+      {isDebugMode && (
+        <div style={{ float: 'right', transform: 'translate(-12px, -32px)' }}>
+          <HorizontalGroup>
+            <IconButton name="cloud-upload" size="lg" key="cloud-upload" onClick={openPriorityWriter} />
+          </HorizontalGroup>
+        </div>
+      )}
       {renderPanelType(PanelType.DISPLAY) && (
         <DisplayPanel
           key={key}
@@ -451,8 +453,8 @@ const _BasePanel: React.FC<Props> = (props: Props) => {
           }}
         />
       )}
-      <InfoHeader currentPriority={currentPriority} writerPriority={writerPriority} />
-      {isRunning && (
+      {isDebugMode && <InfoHeader currentPriority={currentPriority} writerPriority={writerPriority} />}
+      {isRunning && isDebugMode && (
         <div className={styles.overlayRunning}>
           <LoadingPlaceholder />
         </div>

--- a/src/module.tsx
+++ b/src/module.tsx
@@ -384,6 +384,12 @@ export const plugin = new PanelPlugin<PanelOptions>(BasePanel)
         showIf: (currentConfig: PanelOptions) => {
           return currentConfig.overrideBISettings;
         },
+      })
+      .addBooleanSwitch({
+        path: 'isDebugMode',
+        name: 'Debug Mode',
+        defaultValue: false,
+        category: [CategoryType.Debug],
       });
   })
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -115,6 +115,7 @@ export enum CategoryType {
   ButtonColorSettings = 'Button Color Settings',
   SliderColorSettings = 'Slider Color Settings',
   Background = 'Background',
+  Debug = 'Debug Options',
 }
 
 export interface SwitchOptions {
@@ -149,6 +150,7 @@ export interface PanelOptions
     NumericOptions,
     SwitchOptions {
   panelType: PanelType;
+  isDebugMode: boolean;
 }
 
 export interface Priority {


### PR DESCRIPTION
# Tickets
- #6 

# Tasks
- Add Debug flag in Panel Options
- Debug flag will toggle visibility for various info components in the Widget title.


# Screenshots
![image](https://github.com/NubeIO/grafana-rubix-os-read-write-panel/assets/9533579/6c7e8843-fb24-4f80-af80-65e67b850346)

![image](https://github.com/NubeIO/grafana-rubix-os-read-write-panel/assets/9533579/631736a4-6e09-4726-969d-9116f299c3c3)
